### PR TITLE
Refactor TemplateOptions With Hull Types

### DIFF
--- a/pkg/chart/capabilities.go
+++ b/pkg/chart/capabilities.go
@@ -1,0 +1,16 @@
+package chart
+
+import (
+	"fmt"
+
+	helmChartUtil "helm.sh/helm/v3/pkg/chartutil"
+)
+
+type Capabilities helmChartUtil.Capabilities
+
+func toCapabilitiesArgs(capOpts *Capabilities) string {
+	if capOpts == nil || capOpts == (*Capabilities)(helmChartUtil.DefaultCapabilities) {
+		return ""
+	}
+	return fmt.Sprintf("--kube-version '%s'", capOpts.KubeVersion.Version)
+}

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -52,7 +52,7 @@ func (c *chart) GetHelmChart() *helmChart.Chart {
 
 func (c *chart) RenderTemplate(opts *TemplateOptions) (Template, error) {
 	opts = opts.setDefaults(c.Metadata.Name)
-	values, err := opts.ValuesOptions.MergeValues(nil)
+	values, err := opts.Values.ToMap()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -56,7 +56,7 @@ func (c *chart) RenderTemplate(opts *TemplateOptions) (Template, error) {
 	if err != nil {
 		return nil, err
 	}
-	renderValues, err := helmChartUtil.ToRenderValues(c.Chart, values, opts.Release, opts.Capabilities)
+	renderValues, err := helmChartUtil.ToRenderValues(c.Chart, values, opts.Release, (*helmChartUtil.Capabilities)(opts.Capabilities))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -56,7 +56,7 @@ func (c *chart) RenderTemplate(opts *TemplateOptions) (Template, error) {
 	if err != nil {
 		return nil, err
 	}
-	renderValues, err := helmChartUtil.ToRenderValues(c.Chart, values, opts.Release, (*helmChartUtil.Capabilities)(opts.Capabilities))
+	renderValues, err := helmChartUtil.ToRenderValues(c.Chart, values, helmChartUtil.ReleaseOptions(opts.Release), (*helmChartUtil.Capabilities)(opts.Capabilities))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aiyengar2/hull/pkg/utils"
 	"github.com/stretchr/testify/assert"
-	helmValues "helm.sh/helm/v3/pkg/cli/values"
 )
 
 func TestNewChart(t *testing.T) {
@@ -89,7 +88,7 @@ func TestRenderTemplate(t *testing.T) {
 			Name:  "Bad Values",
 			Chart: c,
 			Opts: &TemplateOptions{
-				ValuesOptions: &helmValues.Options{
+				Values: &Values{
 					Values: []string{"i-am-a-bad-option#2@"},
 				},
 			},

--- a/pkg/chart/release.go
+++ b/pkg/chart/release.go
@@ -1,0 +1,14 @@
+package chart
+
+import (
+	helmChartUtil "helm.sh/helm/v3/pkg/chartutil"
+)
+
+type Release helmChartUtil.ReleaseOptions
+
+func toReleaseArgs(relOpts Release) string {
+	if relOpts.IsUpgrade {
+		return "--is-upgrade"
+	}
+	return ""
+}

--- a/pkg/chart/template.go
+++ b/pkg/chart/template.go
@@ -184,7 +184,7 @@ func (t *template) HelmLint(tT *testing.T, opts *HelmLintOptions) {
 	}
 
 	command := "helm lint --strict"
-	valArgs := toValuesArgs(t.Options.ValuesOptions)
+	valArgs := toValuesArgs(t.Options.Values)
 	if len(valArgs) > 0 {
 		command += " " + valArgs
 	}

--- a/pkg/chart/template_options.go
+++ b/pkg/chart/template_options.go
@@ -19,7 +19,7 @@ func NewTemplateOptions(name, namespace string) *TemplateOptions {
 type TemplateOptions struct {
 	Values       *Values
 	Release      helmChartUtil.ReleaseOptions
-	Capabilities *helmChartUtil.Capabilities
+	Capabilities *Capabilities
 }
 
 func (o *TemplateOptions) SetKubeVersion(version string) *TemplateOptions {
@@ -28,7 +28,7 @@ func (o *TemplateOptions) SetKubeVersion(version string) *TemplateOptions {
 		panic(fmt.Errorf("invalid kubeVersion %s provided: %s", version, err))
 	}
 	if o.Capabilities == nil {
-		o.Capabilities = &helmChartUtil.Capabilities{}
+		o.Capabilities = &Capabilities{}
 	}
 	o.Capabilities.KubeVersion = *kubeVersion
 	return o
@@ -63,7 +63,7 @@ func (o *TemplateOptions) setDefaults(chart string) *TemplateOptions {
 		o.Release.IsInstall = true
 	}
 	if o.Capabilities == nil {
-		o.Capabilities = helmChartUtil.DefaultCapabilities
+		o.Capabilities = (*Capabilities)(helmChartUtil.DefaultCapabilities)
 	}
 	if o.Values == nil {
 		o.Values = NewValues()
@@ -100,11 +100,4 @@ func toReleaseArgs(relOpts helmChartUtil.ReleaseOptions) string {
 		return "--is-upgrade"
 	}
 	return ""
-}
-
-func toCapabilitiesArgs(capOpts *helmChartUtil.Capabilities) string {
-	if capOpts == nil || capOpts == helmChartUtil.DefaultCapabilities {
-		return ""
-	}
-	return fmt.Sprintf("--kube-version '%s'", capOpts.KubeVersion.Version)
 }

--- a/pkg/chart/template_options.go
+++ b/pkg/chart/template_options.go
@@ -8,7 +8,7 @@ import (
 
 func NewTemplateOptions(name, namespace string) *TemplateOptions {
 	o := &TemplateOptions{
-		Release: helmChartUtil.ReleaseOptions{
+		Release: Release{
 			Name:      name,
 			Namespace: namespace,
 		},
@@ -18,7 +18,7 @@ func NewTemplateOptions(name, namespace string) *TemplateOptions {
 
 type TemplateOptions struct {
 	Values       *Values
-	Release      helmChartUtil.ReleaseOptions
+	Release      Release
 	Capabilities *Capabilities
 }
 
@@ -93,11 +93,4 @@ func (o TemplateOptions) String() string {
 	}
 	args += " <path-to-chart>"
 	return args
-}
-
-func toReleaseArgs(relOpts helmChartUtil.ReleaseOptions) string {
-	if relOpts.IsUpgrade {
-		return "--is-upgrade"
-	}
-	return ""
 }

--- a/pkg/chart/template_test.go
+++ b/pkg/chart/template_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aiyengar2/hull/pkg/utils"
 	"github.com/rancher/wrangler/pkg/objectset"
 	"github.com/stretchr/testify/assert"
-	helmValues "helm.sh/helm/v3/pkg/cli/values"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -231,7 +230,7 @@ func TestTemplateOptionsString(t *testing.T) {
 		{
 			Name: "Custom Values Options",
 			Options: &TemplateOptions{
-				ValuesOptions: &helmValues.Options{
+				Values: &Values{
 					ValueFiles:   []string{"testdata/values.yaml"},
 					Values:       []string{"name=prod"},
 					StringValues: []string{"value=1234"},
@@ -244,7 +243,7 @@ func TestTemplateOptionsString(t *testing.T) {
 		{
 			Name: "Custom Values Options With Multiple Values",
 			Options: &TemplateOptions{
-				ValuesOptions: &helmValues.Options{
+				Values: &Values{
 					ValueFiles:   []string{"testdata/values.yaml", "testdata/values-2.yaml"},
 					Values:       []string{"name=prod", "cluster=world"},
 					StringValues: []string{"value=1234", "hello=4321"},
@@ -314,8 +313,8 @@ func TestTemplateOptionsString(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			assert.Equal(t, tc.String, tc.Options.String())
-			if tc.Options.ValuesOptions != nil {
-				_, err := tc.Options.ValuesOptions.MergeValues(nil)
+			if tc.Options.Values != nil {
+				_, err := tc.Options.Values.ToMap()
 				assert.Nil(t, err, fmt.Sprintf("could not compute values.yaml overrides for command '%s': %s", tc.String, err))
 			}
 		})

--- a/pkg/chart/values.go
+++ b/pkg/chart/values.go
@@ -1,0 +1,87 @@
+package chart
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	helmValues "helm.sh/helm/v3/pkg/cli/values"
+)
+
+type Values helmValues.Options
+
+func NewValues() *Values {
+	return &Values{}
+}
+
+func (v *Values) SetValue(key, value string) *Values {
+	if v == nil {
+		v = &Values{}
+	}
+	v.Values = append(v.Values, fmt.Sprintf("%s=%s", key, value))
+	return v
+}
+
+func (v *Values) Set(key, value interface{}) *Values {
+	jsonValue, err := json.Marshal(value)
+	if err != nil {
+		panic(fmt.Errorf("cannot marshall value %T (%s): %s", value, value, err))
+	}
+	if v == nil {
+		v = &Values{}
+	}
+	v.JSONValues = append(v.JSONValues, fmt.Sprintf("%s=%s", key, jsonValue))
+	return v
+}
+
+func (v *Values) MergeValues(values ...*Values) *Values {
+	ret := &Values{}
+	for _, value := range append([]*Values{v}, values...) {
+		if value == nil {
+			continue
+		}
+		ret.ValueFiles = append(ret.ValueFiles, value.ValueFiles...)
+		ret.Values = append(ret.Values, value.Values...)
+		ret.StringValues = append(ret.StringValues, value.StringValues...)
+		ret.FileValues = append(ret.FileValues, value.FileValues...)
+		ret.JSONValues = append(ret.JSONValues, value.JSONValues...)
+	}
+	return ret
+}
+
+func (v *Values) ToMap() (map[string]interface{}, error) {
+	return (*helmValues.Options)(v).MergeValues(nil)
+}
+
+func toValuesArgs(valOpts *Values) string {
+	if valOpts == nil {
+		return ""
+	}
+	var args string
+	if len(valOpts.ValueFiles) > 0 {
+		for _, setArg := range valOpts.ValueFiles {
+			args += fmt.Sprintf(" -f %s", setArg)
+		}
+	}
+	if len(valOpts.Values) > 0 {
+		for _, setArg := range valOpts.Values {
+			args += fmt.Sprintf(" --set '%s'", setArg)
+		}
+	}
+	if len(valOpts.StringValues) > 0 {
+		for _, setArg := range valOpts.StringValues {
+			args += fmt.Sprintf(" --set-string '%s'", setArg)
+		}
+	}
+	if len(valOpts.FileValues) > 0 {
+		for _, setArg := range valOpts.FileValues {
+			args += fmt.Sprintf(" --set-file '%s'", setArg)
+		}
+	}
+	if len(valOpts.JSONValues) > 0 {
+		for _, setArg := range valOpts.JSONValues {
+			args += fmt.Sprintf(" --set-json '%s'", setArg)
+		}
+	}
+	return strings.TrimPrefix(args, " ")
+}

--- a/pkg/chart/values_test.go
+++ b/pkg/chart/values_test.go
@@ -1,0 +1,57 @@
+package chart
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeValues(t *testing.T) {
+	first := &Values{
+		ValueFiles:   []string{"testdata/values.yaml"},
+		Values:       []string{"name=prod"},
+		StringValues: []string{"value=1234"},
+		FileValues:   []string{"myfile=testdata/values.yaml"},
+		JSONValues:   []string{"myobj={\"hello\": \"world\"}"},
+	}
+	second := &Values{
+		ValueFiles:   []string{"testdata/values-2.yaml"},
+		Values:       []string{"cluster=world"},
+		StringValues: []string{"hello=4321"},
+		FileValues:   []string{"myscript=testdata/values-2.yaml"},
+		JSONValues:   []string{"myobj2={\"hello\": \"rancher\"}"},
+	}
+	t.Run("Empty Merge", func(t *testing.T) {
+		assert.Equal(t, first, first.MergeValues())
+	})
+
+	t.Run("Nil Merges Into First", func(t *testing.T) {
+		assert.Equal(t, first, first.MergeValues(nil))
+	})
+
+	t.Run("First Merges Into Nil", func(t *testing.T) {
+		var empty Values
+		assert.Equal(t, first, empty.MergeValues(first))
+	})
+
+	t.Run("Second Merges Into First", func(t *testing.T) {
+		expected := &Values{
+			ValueFiles:   []string{"testdata/values.yaml", "testdata/values-2.yaml"},
+			Values:       []string{"name=prod", "cluster=world"},
+			StringValues: []string{"value=1234", "hello=4321"},
+			FileValues:   []string{"myfile=testdata/values.yaml", "myscript=testdata/values-2.yaml"},
+			JSONValues:   []string{"myobj={\"hello\": \"world\"}", "myobj2={\"hello\": \"rancher\"}"},
+		}
+		assert.Equal(t, expected, first.MergeValues(second))
+	})
+	t.Run("First Merges Into Second", func(t *testing.T) {
+		expected := &Values{
+			ValueFiles:   []string{"testdata/values-2.yaml", "testdata/values.yaml"},
+			Values:       []string{"cluster=world", "name=prod"},
+			StringValues: []string{"hello=4321", "value=1234"},
+			FileValues:   []string{"myscript=testdata/values-2.yaml", "myfile=testdata/values.yaml"},
+			JSONValues:   []string{"myobj2={\"hello\": \"rancher\"}", "myobj={\"hello\": \"world\"}"},
+		}
+		assert.Equal(t, expected, second.MergeValues(first))
+	})
+}

--- a/pkg/test/coverage/tracker.go
+++ b/pkg/test/coverage/tracker.go
@@ -10,8 +10,6 @@ import (
 	"github.com/aiyengar2/hull/pkg/tpl"
 	"github.com/aiyengar2/hull/pkg/tpl/parse"
 	"github.com/gobwas/glob"
-
-	helmValues "helm.sh/helm/v3/pkg/cli/values"
 )
 
 type Tracker struct {
@@ -133,14 +131,14 @@ func (t *Tracker) Record(templateOptions *chart.TemplateOptions, templateGlobPat
 	// }
 
 	// Get setFields under .Values.*
-	valueOpts := templateOptions.ValuesOptions
+	valueOpts := templateOptions.Values
 	if valueOpts == nil {
-		valueOpts = &helmValues.Options{}
+		valueOpts = chart.NewValues()
 	} else {
 		// at least one value was overridden
 		setFields = append(setFields, ".Values")
 	}
-	values, err := valueOpts.MergeValues(nil)
+	values, err := valueOpts.ToMap()
 	if err != nil {
 		return err
 	}

--- a/pkg/test/suite.go
+++ b/pkg/test/suite.go
@@ -7,8 +7,6 @@ import (
 	"github.com/aiyengar2/hull/pkg/test/coverage"
 	"github.com/aiyengar2/hull/pkg/tpl"
 	"github.com/stretchr/testify/assert"
-
-	helmValues "helm.sh/helm/v3/pkg/cli/values"
 )
 
 type Suite struct {
@@ -28,8 +26,8 @@ func (s *Suite) setDefaults() *Suite {
 		if s.Cases[i].TemplateOptions == nil {
 			s.Cases[i].TemplateOptions = &chart.TemplateOptions{}
 		}
-		if s.Cases[i].TemplateOptions.ValuesOptions == nil {
-			s.Cases[i].TemplateOptions.ValuesOptions = &helmValues.Options{}
+		if s.Cases[i].TemplateOptions.Values == nil {
+			s.Cases[i].TemplateOptions.Values = chart.NewValues()
 		}
 	}
 	return s


### PR DESCRIPTION
Instead of relying on upstream Helm's structs and methods on those structs, this PR wraps upstream Helm's structs into Hull types that have additional functions added to them.

These additional functions will make it easier to build a TemplateOptions struct in a testing suite.