### PR TITLE
Refactor test.Suite to simplify usage

### DIFF
--- a/examples/tests/example/example.go
+++ b/examples/tests/example/example.go
@@ -5,11 +5,10 @@ import (
 	"github.com/aiyengar2/hull/pkg/checker"
 	"github.com/aiyengar2/hull/pkg/test"
 	"github.com/aiyengar2/hull/pkg/utils"
-	"github.com/rancher/wrangler/pkg/relatedresource"
 	"github.com/stretchr/testify/assert"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var ChartPath = utils.MustGetPathFromModuleRoot("..", "testdata", "charts", "example-chart")
@@ -22,46 +21,6 @@ var (
 var suite = test.Suite{
 	ChartPath: ChartPath,
 
-	TemplateChecks: []test.TemplateCheck{
-		{
-			Name: "All Deployments Have ServiceAccount",
-			Func: checker.NewCheckFunc(
-				checker.OnResources(func(tc *checker.TestContext, deployments []*appsv1.Deployment) {
-					serviceAccountsToCheck := map[relatedresource.Key]bool{}
-					for _, deployment := range deployments {
-						key := relatedresource.NewKey(
-							deployment.Namespace,
-							deployment.Spec.Template.Spec.ServiceAccountName,
-						)
-						serviceAccountsToCheck[key] = false
-					}
-					checker.Store(tc, "ServiceAccountsToCheck", serviceAccountsToCheck)
-				}),
-				checker.OnResources(func(tc *checker.TestContext, serviceAccounts []*corev1.ServiceAccount) {
-					serviceAccountsToCheck, ok := checker.Get[string, map[relatedresource.Key]bool](tc, "ServiceAccountsToCheck")
-					if !ok {
-						return
-					}
-					for _, serviceAccount := range serviceAccounts {
-						key := relatedresource.NewKey(serviceAccount.Namespace, serviceAccount.Name)
-						_, ok := serviceAccountsToCheck[key]
-						if !ok {
-							continue
-						}
-						serviceAccountsToCheck[key] = true
-					}
-					for key, exists := range serviceAccountsToCheck {
-						if exists {
-							tc.T.Logf("serviceaccount %s exists in this Helm chart", key)
-						} else {
-							tc.T.Errorf("serviceaccount %s is not in this chart", key)
-						}
-					}
-				}),
-			),
-		},
-	},
-
 	Cases: []test.Case{
 		{
 			Name: "Using Defaults",
@@ -69,24 +28,51 @@ var suite = test.Suite{
 			TemplateOptions: chart.NewTemplateOptions(DefaultReleaseName, DefaultNamespace),
 		},
 		{
-			Name: "Setting .Values.args[0] to --debug",
+			Name: "Set .Values.args[0] to --debug",
 
 			TemplateOptions: chart.NewTemplateOptions(DefaultReleaseName, DefaultNamespace).SetValue("args[0]", "--debug"),
+		},
+		{
+			Name: "Set .Values.args[0] to --trace",
 
-			ValueChecks: []test.ValueCheck{
-				{
-					Name: "Passes --debug Flag To Deployment",
-					Covers: []string{
-						"templates/deployment.yaml",
-					},
-					Func: checker.NewCheckFunc(
-						checker.PerResource(func(tc *checker.TestContext, deployment *appsv1.Deployment) {
-							for _, container := range deployment.Spec.Template.Spec.Containers {
-								assert.Equal(tc.T, []string{"--debug"}, container.Args, "container %s in Deployment %s/%s does not have debug", container.Name, deployment.Namespace, deployment.Name)
-							}
-						}),
-					),
-				},
+			TemplateOptions: chart.NewTemplateOptions(DefaultReleaseName, DefaultNamespace).SetValue("args[0]", "--trace"),
+		},
+	},
+
+	NamedChecks: []test.NamedCheck{
+		{
+			Name: "All Deployments Have ServiceAccount",
+		},
+		{
+			Name: "Check Container Args",
+			Covers: []string{
+				"templates/deployment.yaml",
+			},
+
+			Checks: test.Checks{
+				checker.PerWorkload(func(tc *checker.TestContext, obj metav1.Object, podTemplateSpec corev1.PodTemplateSpec) {
+					if obj.GetNamespace() != checker.MustRenderValue[string](tc, ".Release.Namespace") {
+						return
+					}
+					if obj.GetName() != checker.MustRenderValue[string](tc, ".Release.Name") {
+						return
+					}
+					expectedArgs := checker.MustRenderValue[[]string](tc, ".Values.args")
+					for _, container := range podTemplateSpec.Spec.Containers {
+						if len(expectedArgs) == 0 {
+							assert.Nil(tc.T, container.Args,
+								"expected container %s in %T %s to have no args",
+								container.Name, obj, checker.Key(obj),
+							)
+						} else {
+							assert.Equal(tc.T,
+								expectedArgs, container.Args,
+								"container %s in %T %s does not have correct args",
+								container.Name, obj, checker.Key(obj),
+							)
+						}
+					}
+				}),
 			},
 		},
 	},

--- a/examples/tests/example/resources.go
+++ b/examples/tests/example/resources.go
@@ -1,0 +1,84 @@
+package example
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aiyengar2/hull/pkg/checker"
+	"github.com/aiyengar2/hull/pkg/test"
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func init() {
+	suite.NamedChecks = append(suite.NamedChecks, test.NamedCheck{
+		Name:   "All Resources Have Helm Release Labels",
+		Checks: AllResourcesHaveHelmReleaseLabels,
+	})
+}
+
+// Check that all resources have expected Helm release labels
+var AllResourcesHaveHelmReleaseLabels = test.Checks{
+	checker.Once(func(tc *checker.TestContext) {
+		chartName := checker.MustRenderValue[string](tc, ".Chart.Name")
+		releaseName := checker.MustRenderValue[string](tc, ".Release.Name")
+		normalizedChartVersion := strings.ReplaceAll(checker.MustRenderValue[string](tc, ".Chart.Version"), "+", "_")
+		nameOverride, hasNameOverride := checker.RenderValue[string](tc, ".Values.nameOverride")
+		checker.MapSet(tc, "Default Labels",
+			"app.kubernetes.io/managed-by",
+			"Helm",
+		)
+		checker.MapSet(tc, "Default Labels",
+			"app.kubernetes.io/instance",
+			releaseName,
+		)
+		checker.MapSet(tc, "Default Labels",
+			"app.kubernetes.io/version",
+			normalizedChartVersion,
+		)
+		if hasNameOverride && len(nameOverride) != 0 {
+			checker.MapSet(tc, "Default Labels",
+				"app.kubernetes.io/part-of",
+				nameOverride,
+			)
+		} else {
+			checker.MapSet(tc, "Default Labels",
+				"app.kubernetes.io/part-of",
+				chartName,
+			)
+		}
+		checker.MapSet(tc, "Default Labels",
+			"chart",
+			fmt.Sprintf("%s-%s",
+				chartName,
+				normalizedChartVersion,
+			),
+		)
+		checker.MapSet(tc, "Default Labels",
+			"release",
+			releaseName,
+		)
+		checker.MapSet(tc, "Default Labels",
+			"heritage",
+			"Helm",
+		)
+	}),
+	checker.PerResource(func(tc *checker.TestContext, obj *unstructured.Unstructured) {
+		expectedLabels, ok := checker.Get[string, map[string]string](tc, "Default Labels")
+		if !ok {
+			assert.True(tc.T, ok)
+			return
+		}
+		objLabels := obj.GetLabels()
+		relevantObjLabels := map[string]string{}
+		for k := range expectedLabels {
+			objVal, ok := objLabels[k]
+			if !ok {
+				continue
+			}
+			relevantObjLabels[k] = objVal
+		}
+		assert.Equal(tc.T, expectedLabels, relevantObjLabels, "%s %s's labels do not match expected labels", obj.GroupVersionKind().Kind, checker.Key(obj))
+	}),
+}

--- a/examples/tests/example/workloads.go
+++ b/examples/tests/example/workloads.go
@@ -1,0 +1,104 @@
+package example
+
+import (
+	"fmt"
+
+	"github.com/aiyengar2/hull/pkg/checker"
+	"github.com/aiyengar2/hull/pkg/test"
+	"github.com/rancher/wrangler/pkg/relatedresource"
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func init() {
+	suite.NamedChecks = append(suite.NamedChecks,
+		test.NamedCheck{
+			Name:   "All Workloads Have Service Account",
+			Checks: AllWorkloadsHaveServiceAccount,
+		},
+		test.NamedCheck{
+			Name:   "All Workloads Have Node Selectors And Tolerations For OS",
+			Checks: AllWorkloadsHaveNodeSelectorsAndTolerationsForOS,
+		},
+	)
+}
+
+// Check that every Workload has a ServiceAccount deployed with it
+var AllWorkloadsHaveServiceAccount = test.Checks{
+	checker.OnWorkloads(func(tc *checker.TestContext, podTemplateSpecs map[metav1.Object]corev1.PodTemplateSpec) {
+		for obj, podTemplateSpec := range podTemplateSpecs {
+			key := relatedresource.NewKey(
+				obj.GetNamespace(),
+				podTemplateSpec.Spec.ServiceAccountName,
+			)
+			checker.MapSet(tc, "ServiceAccountsToCheck", key, false)
+		}
+	}),
+	checker.PerResource(func(tc *checker.TestContext, serviceAccount *corev1.ServiceAccount) {
+		key := checker.Key(serviceAccount)
+		_, exists := checker.MapGet[string, relatedresource.Key, bool](tc, "ServiceAccountsToCheck", key)
+		if !exists {
+			// does not belong to any workload
+			tc.T.Logf("warn: serviceaccount %s is not tied to any workload", key)
+			return
+		}
+		checker.MapSet(tc, "ServiceAccountsToCheck", key, true)
+	}),
+	checker.Once(func(tc *checker.TestContext) {
+		checker.MapFor(tc, "ServiceAccountsToCheck", func(key relatedresource.Key, exists bool) {
+			assert.True(tc.T, exists, "serviceaccount %s is not in this chart", key)
+		})
+	}),
+}
+
+var AllWorkloadsHaveNodeSelectorsAndTolerationsForOS = test.Checks{
+	checker.PerWorkload(func(tc *checker.TestContext, obj metav1.Object, podTemplateSpec corev1.PodTemplateSpec) {
+		nodeSelector := podTemplateSpec.Spec.NodeSelector
+		betaOSVal, hasBetaOSAnnotation := nodeSelector["beta.kubernetes.io/os"]
+		osVal, hasOSAnnotation := nodeSelector["kubernetes.io/os"]
+		if hasBetaOSAnnotation && hasOSAnnotation {
+			assert.Equal(tc.T, osVal, betaOSVal, fmt.Sprintf("%T %s is has conflicting values for nodeSelector beta.kubernetes.io/os or kubernetes.io/os", obj, checker.Key(obj)))
+		}
+		if hasBetaOSAnnotation {
+			if betaOSVal == "windows" {
+				checker.MapSet(tc, "Windows Workload", &podTemplateSpec, true)
+			}
+			tc.T.Logf("warn: beta.kubernetes.io/os nodeSelector has been deprecated but is used in %T %s", obj, checker.Key(obj))
+			assert.Contains(tc.T, []string{"linux", "windows"}, betaOSVal, fmt.Sprintf("%T %s cannot have value for beta.kubernetes.io/os that is not 'linux' or 'windows': found %s", obj, checker.Key(obj), betaOSVal))
+		}
+		if hasOSAnnotation {
+			if osVal == "windows" {
+				checker.MapSet(tc, "Windows Workload", &obj, true)
+			}
+			assert.Contains(tc.T, []string{"linux", "windows"}, osVal, fmt.Sprintf("%T %s cannot have value for kubernetes.io/os that is not 'linux' or 'windows': found %s", obj, checker.Key(obj), osVal))
+		}
+		assert.False(tc.T, !hasBetaOSAnnotation && !hasOSAnnotation, fmt.Sprintf("%T %s is missing OS key for nodeSelector, expected to find either beta.kubernetes.io/os or kubernetes.io/os", obj, checker.Key(obj)))
+	}),
+	checker.PerWorkload(func(tc *checker.TestContext, obj metav1.Object, podTemplateSpec corev1.PodTemplateSpec) {
+		isWindowsWorkload, _ := checker.MapGet[string, *metav1.Object, bool](tc, "Windows Workload", &obj)
+		if isWindowsWorkload {
+			// no need to check for tolerations
+			return
+		}
+		tolerations := podTemplateSpec.Spec.Tolerations
+		var foundToleration bool
+		for _, toleration := range tolerations {
+			if toleration.Key != "cattle.io/os" {
+				continue
+			}
+			if toleration.Value != "linux" {
+				continue
+			}
+			if toleration.Effect != "NoSchedule" {
+				continue
+			}
+			if toleration.Operator != "Equal" {
+				continue
+			}
+			foundToleration = true
+		}
+		assert.True(tc.T, foundToleration, "could not find toleration in workload %T %s that tolerates the NoSchedule 'cattle.io/os: linux' taint", obj, checker.Key(obj))
+	}),
+}

--- a/pkg/checker/context.go
+++ b/pkg/checker/context.go
@@ -1,6 +1,12 @@
 package checker
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aiyengar2/hull/pkg/extract"
+	helmChartUtil "helm.sh/helm/v3/pkg/chartutil"
+)
 
 func NewContext() *TestContext {
 	return &TestContext{
@@ -12,6 +18,8 @@ type TestContext struct {
 	T *testing.T
 
 	Data map[interface{}]interface{}
+
+	RenderValues helmChartUtil.Values
 }
 
 func Store[K comparable, V interface{}](tc *TestContext, key K, value V) {
@@ -24,4 +32,16 @@ func Get[K comparable, V interface{}](tc *TestContext, key K) (V, bool) {
 		return *new(V), ok
 	}
 	return value.(V), ok
+}
+
+func RenderValue[O interface{}](tc *TestContext, path string) (O, bool) {
+	return extract.Field[O](tc.RenderValues, path)
+}
+
+func MustRenderValue[O interface{}](tc *TestContext, path string) O {
+	val, ok := extract.Field[O](tc.RenderValues, path)
+	if !ok {
+		panic(fmt.Sprintf("cannot extract value at path %s with type %T in values passed into TestContext for %s", path, *new(O), tc.T.Name()))
+	}
+	return val
 }

--- a/pkg/checker/context_test.go
+++ b/pkg/checker/context_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	helmChart "helm.sh/helm/v3/pkg/chart"
 )
 
 func TestTestContext(t *testing.T) {
@@ -33,5 +34,76 @@ func TestTestContext(t *testing.T) {
 		set, found := Get[string, map[string]interface{}](tc, "nilMap")
 		assert.True(t, found)
 		assert.Nil(t, set)
+	})
+	t.Run("RenderValue When Unset", func(t *testing.T) {
+		value, found := RenderValue[string](tc, ".Chart.Name")
+		assert.False(t, found)
+		assert.Equal(t, "", value)
+	})
+	t.Run("MustRenderValue When Unset", func(t *testing.T) {
+		defer func() {
+			err := recover()
+			if err == nil {
+				assert.Fail(t, "should not have passed MustRenderValue")
+			}
+		}()
+		MustRenderValue[string](tc, ".Chart.Name")
+	})
+	tc.RenderValues = map[string]interface{}{
+		"Chart": helmChart.Metadata{
+			Name: "my-chart",
+		},
+	}
+	tc.RenderValues = map[string]interface{}{
+		"Chart": helmChart.Metadata{
+			Name: "my-chart",
+		},
+	}
+	t.Run("RenderValue When Set Struct", func(t *testing.T) {
+		value, found := RenderValue[string](tc, ".Chart.Name")
+		assert.True(t, found)
+		assert.Equal(t, "my-chart", value)
+	})
+	tc.RenderValues = map[string]interface{}{
+		"Chart": helmChart.Metadata{
+			Name: "my-chart-2",
+		},
+		"Values": map[string]interface{}{
+			"data": map[string]interface{}{
+				"hello": "world",
+			},
+		},
+	}
+	t.Run("MustRenderValue When Set Struct", func(t *testing.T) {
+		defer func() {
+			err := recover()
+			if err != nil {
+				assert.Fail(t, "should have passed MustRenderValue", err)
+			}
+		}()
+		MustRenderValue[string](tc, ".Chart.Name")
+	})
+	t.Run("RenderValue When Updated", func(t *testing.T) {
+		value, found := RenderValue[string](tc, ".Chart.Name")
+		assert.True(t, found)
+		assert.Equal(t, "my-chart-2", value)
+	})
+	t.Run("RenderValue With Set Map", func(t *testing.T) {
+		value, found := RenderValue[map[string]interface{}](tc, ".Values.data")
+		assert.True(t, found)
+		assert.Equal(t, map[string]interface{}{"hello": "world"}, value)
+	})
+	t.Run("Convert RenderValue Type To String Map", func(t *testing.T) {
+		value, found := RenderValue[map[string]string](tc, ".Values.data")
+		assert.True(t, found)
+		assert.Equal(t, map[string]string{"hello": "world"}, value)
+	})
+	t.Run("Convert RenderValue Type To Struct", func(t *testing.T) {
+		type HelloWorld struct {
+			Hello string `json:"hello"`
+		}
+		value, found := RenderValue[HelloWorld](tc, ".Values.data")
+		assert.True(t, found)
+		assert.Equal(t, HelloWorld{Hello: "world"}, value)
 	})
 }

--- a/pkg/extract/extract.go
+++ b/pkg/extract/extract.go
@@ -1,0 +1,120 @@
+package extract
+
+import (
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/rancher/wrangler/pkg/data/convert"
+)
+
+var renderValuesCmdRe = regexp.MustCompile(`(?P<field>[^\[\]]*)+(?P<indices>\[.*\])*`)
+
+func Field[O interface{}](obj interface{}, path string) (O, bool) {
+	var ok bool
+	for _, cmd := range strings.Split(path, ".") {
+		// process 'Values' in something like 'Values[0][1][2]'
+		matches := renderValuesCmdRe.FindStringSubmatch(cmd)
+		fieldIdx := renderValuesCmdRe.SubexpIndex("field")
+		field := matches[fieldIdx]
+		if len(field) > 0 {
+			obj, ok = getValueFromObject(obj, field)
+			if !ok {
+				return *new(O), false
+			}
+		}
+		// process all the other indices
+		indicesIdx := renderValuesCmdRe.SubexpIndex("indices")
+		multipleMatches := renderValuesCmdRe.FindAllStringSubmatch(cmd, -1)
+		for _, matches := range multipleMatches {
+			indicesString := matches[indicesIdx]
+			if len(indicesString) < 2 {
+				// no match found for index
+				continue
+			}
+			indices := strings.Split(indicesString[1:len(indicesString)-1], "][")
+			for _, index := range indices {
+				if index == "" {
+					return *new(O), false
+				}
+				hasDoubleQuotes := strings.HasPrefix(index, `"`) && strings.HasSuffix(index, `"`)
+				hasSingleQuotes := strings.HasPrefix(index, `'`) && strings.HasSuffix(index, `'`)
+				if hasDoubleQuotes || hasSingleQuotes {
+					// found string index for map
+					field = index[1 : len(index)-1]
+					obj, ok = getValueFromObject(obj, field)
+					if !ok {
+						return *new(O), false
+					}
+				} else {
+					// should be integer index
+					index, err := strconv.Atoi(index)
+					if err != nil {
+						return *new(O), false
+					}
+					obj, ok = getValueFromSlice(obj, index)
+					if !ok {
+						return *new(O), false
+					}
+				}
+			}
+		}
+	}
+	typedObj, ok := obj.(O)
+	if !ok {
+		// try marshalling and unmarshalling
+		err := convert.ToObj(obj, &typedObj)
+		if err != nil {
+			return *new(O), false
+		}
+	}
+	return typedObj, true
+}
+
+func getValueFromObject(renderValues interface{}, key string) (interface{}, bool) {
+	if renderValues == nil {
+		return nil, false
+	}
+	var val reflect.Value
+	switch reflect.TypeOf(renderValues).Kind() {
+	case reflect.Map:
+		val = reflect.ValueOf(renderValues).MapIndex(reflect.ValueOf(key))
+	case reflect.Struct:
+		val = reflect.ValueOf(renderValues).FieldByName(key)
+	case reflect.Pointer:
+		underlyingRenderVal := reflect.Indirect(reflect.ValueOf(renderValues))
+		if underlyingRenderVal.Kind() == reflect.Invalid {
+			return nil, false
+		}
+		return getValueFromObject(underlyingRenderVal.Interface(), key)
+	default:
+		return nil, false
+	}
+	if val.Kind() == reflect.Invalid {
+		return nil, false
+	}
+	if !val.CanInterface() {
+		// might be a hidden field in a struct
+		return nil, false
+	}
+	return val.Interface(), true
+}
+
+func getValueFromSlice(renderValues interface{}, index int) (interface{}, bool) {
+	if renderValues == nil {
+		return nil, false
+	}
+	var val reflect.Value
+	switch reflect.TypeOf(renderValues).Kind() {
+	case reflect.Slice, reflect.Array:
+		renderValuesVal := reflect.ValueOf(renderValues)
+		if index >= renderValuesVal.Len() {
+			return nil, false
+		}
+		val = renderValuesVal.Index(index)
+	default:
+		return nil, false
+	}
+	return val.Interface(), true
+}

--- a/pkg/extract/extract_test.go
+++ b/pkg/extract/extract_test.go
@@ -1,0 +1,396 @@
+package extract
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestField(t *testing.T) {
+	type customStruct struct {
+		MyValue       bool
+		myHiddenValue string
+		MyMap         map[string]interface{}
+		MyStringMap   map[string]string
+	}
+	var nilStructPtr *customStruct
+
+	testCases := []struct {
+		Name     string
+		Obj      interface{}
+		Path     string
+		Expected interface{}
+		NotFound bool
+	}{
+		{
+			Name: "Int Value",
+			Obj: map[string]interface{}{
+				"hello": 1,
+			},
+			Path:     "hello",
+			Expected: 1,
+		},
+		{
+			Name: "String Value",
+			Obj: map[string]interface{}{
+				"hello": "world",
+			},
+			Path:     "hello",
+			Expected: "world",
+		},
+		{
+			Name: "Slice Value",
+			Obj: map[string]interface{}{
+				"hello": []interface{}{
+					"world", "rancher",
+				},
+			},
+			Path: "hello",
+			Expected: []interface{}{
+				"world", "rancher",
+			},
+		},
+		{
+			Name: "Slice At Index",
+			Obj: []interface{}{
+				"hello", "world",
+			},
+			Path:     "[0]",
+			Expected: "hello",
+		},
+		{
+			Name: "Slice At Second Index",
+			Obj: []interface{}{
+				"hello", "world",
+			},
+			Path:     "[1]",
+			Expected: "world",
+		},
+		{
+			Name: "Slice At Nonexistent Index",
+			Obj: []interface{}{
+				"hello", "world",
+			},
+			Path:     "[2]",
+			NotFound: true,
+		},
+		{
+			Name: "Slice At Bad Index",
+			Obj: []interface{}{
+				"hello", "world",
+			},
+			Path:     "[]",
+			NotFound: true,
+		},
+		{
+			Name:     "Nil Key Access",
+			Obj:      nil,
+			Path:     "hello",
+			NotFound: true,
+		},
+		{
+			Name:     "Nil Int Index",
+			Obj:      nil,
+			Path:     "[5]",
+			NotFound: true,
+		},
+		{
+			Name:     "Nil String Index",
+			Obj:      nil,
+			Path:     `["hello"]`,
+			NotFound: true,
+		},
+		{
+			Name:     "Nil Struct",
+			Obj:      nilStructPtr,
+			Path:     `MyValue`,
+			NotFound: true,
+		},
+		{
+			Name:     "Empty Bool From Struct",
+			Obj:      customStruct{},
+			Path:     "MyValue",
+			Expected: false,
+		},
+		{
+			Name:     "Empty Map From Struct",
+			Obj:      customStruct{},
+			Path:     "MyMap",
+			Expected: (map[string]interface{})(nil),
+		},
+		{
+			Name: "Dot",
+			Obj: []interface{}{
+				"hello", "world",
+			},
+			Path: ".",
+			Expected: []interface{}{
+				"hello", "world",
+			},
+		},
+		{
+			Name: "Double Dot",
+			Obj: []interface{}{
+				"hello", "world",
+			},
+			Path: "..",
+			Expected: []interface{}{
+				"hello", "world",
+			},
+		},
+		{
+			Name: "Map",
+			Obj: map[string]interface{}{
+				"hello": map[string]interface{}{
+					"world": "rancher",
+				},
+			},
+			Path: "hello",
+			Expected: map[string]interface{}{
+				"world": "rancher",
+			},
+		},
+		{
+			Name: "Map At Key",
+			Obj: map[string]interface{}{
+				"hello": map[string]interface{}{
+					"world": "rancher",
+				},
+			},
+			Path:     "hello.world",
+			Expected: "rancher",
+		},
+		{
+			Name: "Map At String Index",
+			Obj: map[string]interface{}{
+				"hello": map[string]interface{}{
+					"world": "rancher",
+				},
+			},
+			Path:     `hello["world"]`,
+			Expected: "rancher",
+		},
+		{
+			Name: "Map At String Index With Single Quotes",
+			Obj: map[string]interface{}{
+				"hello": map[string]interface{}{
+					"world": "rancher",
+				},
+			},
+			Path:     `hello['world']`,
+			Expected: "rancher",
+		},
+		{
+			Name: "Map At String Index with Double Quotes",
+			Obj: map[string]interface{}{
+				"hello": map[string]interface{}{
+					"world": "rancher",
+				},
+			},
+			Path:     `hello["world"]`,
+			Expected: "rancher",
+		},
+		{
+			Name: "Complex Combination",
+			Obj: map[string]interface{}{
+				"hello": map[string]interface{}{
+					"world": []interface{}{
+						"not me",
+						"not me either",
+						map[string]interface{}{
+							"rancher": map[string]interface{}{
+								"world": []interface{}{
+									"not me again",
+									"not me again either",
+									map[string]interface{}{
+										"cattle": []map[string]interface{}{
+											{
+												"hull": []int{
+													1,
+													9001,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Path:     `hello.world[2].rancher["world"][2]["cattle"][0].hull[1]`,
+			Expected: 9001,
+		},
+		{
+			Name: "Accessing Embedded Structs",
+			Obj: map[string]interface{}{
+				"Chart": customStruct{
+					MyValue: true,
+				},
+			},
+			Path:     "Chart.MyValue",
+			Expected: true,
+		},
+		{
+			Name: "Accessing Hidden Fields In Embedded Structs",
+			Obj: map[string]interface{}{
+				"Chart": customStruct{
+					myHiddenValue: "secret",
+				},
+			},
+			Path:     "Chart.myHiddenValue",
+			NotFound: true,
+		},
+		{
+			Name: "Accessing Nested Fields In Embedded Structs",
+			Obj: map[string]interface{}{
+				"Chart": customStruct{
+					MyMap: map[string]interface{}{
+						"hello": customStruct{
+							MyStringMap: map[string]string{
+								"world": "rancher",
+							},
+						},
+					},
+				},
+			},
+			Path:     "Chart.MyMap.hello.MyStringMap.world",
+			Expected: "rancher",
+		},
+		{
+			Name: "Invalid Field In Struct",
+			Obj: map[string]interface{}{
+				"Chart": customStruct{
+					MyMap: map[string]interface{}{
+						"hello": customStruct{
+							MyStringMap: map[string]string{
+								"world": "rancher",
+							},
+						},
+					},
+				},
+			},
+			Path:     "Chart.MyNonExistentKey",
+			NotFound: true,
+		},
+		{
+			Name: "Accessing Field In Pointer Struct",
+			Obj: map[string]interface{}{
+				"Chart": &customStruct{
+					MyMap: map[string]interface{}{
+						"hello": &customStruct{
+							MyStringMap: map[string]string{
+								"world": "rancher",
+							},
+						},
+					},
+				},
+			},
+			Path:     "Chart.MyNonExistentKey",
+			NotFound: true,
+		},
+		{
+			Name: "Invalid Int Index Access On Map",
+			Obj: map[string]interface{}{
+				"hello": "world",
+			},
+			Path:     "hello[0]",
+			NotFound: true,
+		},
+		{
+			Name: "Invalid String Index Access On Slice",
+			Obj: map[string]interface{}{
+				"hello": []interface{}{
+					"world", "rancher",
+				},
+			},
+			Path:     `hello["world"]`,
+			NotFound: true,
+		},
+		{
+			Name: "Invalid String Index Without Quotes",
+			Obj: map[string]interface{}{
+				"hello": []interface{}{
+					"world", "rancher",
+				},
+			},
+			Path:     `hello[world]`,
+			NotFound: true,
+		},
+		{
+			Name: "Empty String Index With Double Quotes",
+			Obj: map[string]interface{}{
+				"hello": map[string]interface{}{
+					"": "rancher",
+				},
+			},
+			Path:     `hello[""]`,
+			Expected: "rancher",
+		},
+		{
+			Name: "Empty String Index With Single Quotes",
+			Obj: map[string]interface{}{
+				"hello": map[string]interface{}{
+					"": "rancher",
+				},
+			},
+			Path:     `hello[""]`,
+			Expected: "rancher",
+		},
+		{
+			Name: "Invalid Key Access On Slice",
+			Obj: map[string]interface{}{
+				"hello": []interface{}{
+					"world", "rancher",
+				},
+			},
+			Path:     `hello.world`,
+			NotFound: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			value, found := Field[interface{}](tc.Obj, tc.Path)
+			assert.Equal(t, tc.Expected, value)
+			if tc.NotFound {
+				assert.False(t, found, "expected not to find any value in object, found %s", value)
+			} else {
+				assert.True(t, found, "expected to find value %s in object at path %s, found nil", tc.Expected, tc.Path)
+			}
+		})
+	}
+
+	obj := map[string]interface{}{
+		"string": "string",
+		"int":    999,
+		"slice":  []string{"hello", "world"},
+		"map":    map[string]string{"hello": "world"},
+	}
+
+	t.Run("Get String Expect String", func(t *testing.T) {
+		value, found := Field[string](obj, "string")
+		assert.Equal(t, "string", value)
+		assert.True(t, found, "could not find string")
+	})
+	t.Run("Get Int Expect Int", func(t *testing.T) {
+		value, found := Field[int](obj, "int")
+		assert.Equal(t, 999, value)
+		assert.True(t, found, "could not find int")
+	})
+	t.Run("Get Slice Expect Slice", func(t *testing.T) {
+		value, found := Field[[]string](obj, "slice")
+		assert.Equal(t, []string{"hello", "world"}, value)
+		assert.True(t, found, "could not find slice")
+	})
+	t.Run("Get Map Expect Map", func(t *testing.T) {
+		value, found := Field[map[string]string](obj, "map")
+		assert.Equal(t, map[string]string{"hello": "world"}, value)
+		assert.True(t, found, "could not find map")
+	})
+	t.Run("Get String Expect Map", func(t *testing.T) {
+		value, found := Field[map[string]string](obj, "string")
+		assert.Nil(t, value, "expected no value to be found since value at 'string' is string, found this value")
+		assert.False(t, found, "expected no value to be found since value at 'string' is string")
+	})
+}

--- a/pkg/test/checks.go
+++ b/pkg/test/checks.go
@@ -2,21 +2,11 @@ package test
 
 import "github.com/aiyengar2/hull/pkg/checker"
 
-// TemplateCheck is a check that run on every `helm template` call identified by the test Suite
-type TemplateCheck struct {
-	Name string
-	Func checker.CheckFunc
-
-	// OmitCases contains a list of names of test.Cases that, if overridden, would cause a DefaultCheck to skip executing itself on that check
-	OmitCases []string
-}
-
-// ValueCheck is a check that is run on a specific `helm template` call with a given set of values.yaml identified by a given test Case
-type ValueCheck struct {
-	Name string
-	Func checker.CheckFunc
-
-	// Covers is a list of file globs whose objects are covered by this template check
-	// This is used for coverage to be able to identify if the logic in certain files has been checked
+// NamedCheck is a check that run on every `helm template` call identified by the test Suite
+type NamedCheck struct {
+	Name   string
+	Checks Checks
 	Covers []string
 }
+
+type Checks []checker.ChainedCheckFunc

--- a/pkg/test/suite.go
+++ b/pkg/test/suite.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/aiyengar2/hull/pkg/chart"
+	"github.com/aiyengar2/hull/pkg/checker"
 	"github.com/aiyengar2/hull/pkg/test/coverage"
 	"github.com/aiyengar2/hull/pkg/tpl"
 	"github.com/stretchr/testify/assert"
@@ -13,17 +14,17 @@ import (
 var executionErrorRe = regexp.MustCompile(`execution error at \(.*\): (?P<inner>.*)`)
 
 type Suite struct {
-	ChartPath      string
-	DefaultValues  *chart.Values
-	TemplateChecks []TemplateCheck
-	Cases          []Case
-	FailureCases   []FailureCase
+	ChartPath     string
+	DefaultValues *chart.Values
+	NamedChecks   []NamedCheck
+	Cases         []Case
+	FailureCases  []FailureCase
 }
 
 type Case struct {
 	Name            string
 	TemplateOptions *chart.TemplateOptions
-	ValueChecks     []ValueCheck
+	OmitNamedChecks []string
 }
 
 type FailureCase struct {
@@ -124,6 +125,16 @@ func (s *Suite) Run(t *testing.T, opts *SuiteOptions) {
 				t.Errorf("failed to render template: %s", err)
 				return
 			}
+			renderValues, err := c.RenderValues(tc.TemplateOptions)
+			if err != nil {
+				t.Errorf("failed to render values: %s", err)
+				return
+			}
+			beforeChecks := Checks{
+				checker.Once(func(tctx *checker.TestContext) {
+					tctx.RenderValues = renderValues
+				}),
+			}
 			t.Run("HelmLint", func(t *testing.T) {
 				template.HelmLint(t, opts.HelmLint)
 			})
@@ -132,29 +143,28 @@ func (s *Suite) Run(t *testing.T, opts *SuiteOptions) {
 					template.YamlLint(t, opts.YAMLLint.Configuration)
 				})
 			}
-			for _, check := range s.TemplateChecks {
+			for _, check := range s.NamedChecks {
 				// skip cases if necessary
 				var skip bool
-				for _, omitCase := range check.OmitCases {
-					if tc.Name == omitCase {
+				for _, omitCase := range tc.OmitNamedChecks {
+					if check.Name == omitCase {
 						skip = true
 					}
 				}
 				if skip {
 					continue
 				}
-				t.Run(check.Name, func(t *testing.T) {
-					template.Check(t, check.Func)
-				})
-			}
-			for _, check := range tc.ValueChecks {
-				t.Run(check.Name, func(t *testing.T) {
-					template.Check(t, check.Func)
-				})
-				if err := coverageTracker.Record(tc.TemplateOptions, check.Covers); err != nil {
-					t.Errorf("failed to track coverage: %s", err)
-					// do not fail out, you should still continue with other checks
+				if !opts.Coverage.Disabled {
+					if err := coverageTracker.Record(tc.TemplateOptions, check.Covers); err != nil {
+						t.Errorf("failed to track coverage: %s", err)
+						// do not fail out, you should still continue with other checks
+					}
 				}
+				t.Run(check.Name, func(t *testing.T) {
+					template.Check(t, checker.NewCheckFunc(
+						append(beforeChecks, check.Checks...)...,
+					))
+				})
 			}
 		})
 	}


### PR DESCRIPTION
Switches to a model where testers provide **flat** Checks and Cases (as opposed to Cases that nest Checks).

This is feasible with the introduction of the new `pkg/extract` library, which allows us to extract generic objects from paths in the rendered values that are now stored directly in the `*checker.TestContext`. As a result of this, you can now write NamedChecks (previously TemplateChecks) that are parametrized by the `values.yaml` via the use of `checker.MustRenderValues / checker.RenderValues`, which solves the need that the previous `ValueChecks` solved.

This is a big breaking change.