### PR TITLE
Refactor coverage to cover on fields and templates, not filepaths

### DIFF
--- a/examples/tests/example/example.go
+++ b/examples/tests/example/example.go
@@ -46,7 +46,7 @@ var suite = test.Suite{
 		{
 			Name: "Check Container Args",
 			Covers: []string{
-				"templates/deployment.yaml",
+				".Values.args",
 			},
 
 			Checks: test.Checks{

--- a/examples/tests/simple/simple.go
+++ b/examples/tests/simple/simple.go
@@ -37,8 +37,12 @@ var suite = test.Suite{
 
 	NamedChecks: []test.NamedCheck{
 		{
-			Name:   "ConfigMaps have expected data",
-			Covers: []string{"templates/configmap.yaml"},
+			Name: "ConfigMaps have expected data",
+
+			Covers: []string{
+				".Values.data",
+			},
+
 			Checks: test.Checks{
 				checker.PerResource(func(tc *checker.TestContext, configmap *corev1.ConfigMap) {
 					// ensure config key always exists
@@ -63,7 +67,7 @@ var suite = test.Suite{
 				SetValue("shouldFail", "true"),
 
 			Covers: []string{
-				"templates/configmap.yaml",
+				".Values.shouldFail",
 			},
 
 			FailureMessage: ".Values.shouldFail is set to true",
@@ -75,7 +79,7 @@ var suite = test.Suite{
 				SetValue("shouldFailRequired", "true"),
 
 			Covers: []string{
-				"templates/configmap.yaml",
+				".Values.shouldFailRequired",
 			},
 
 			FailureMessage: ".Values.shouldFailRequired is set to true",

--- a/pkg/test/coverage/tracker.go
+++ b/pkg/test/coverage/tracker.go
@@ -9,11 +9,10 @@ import (
 	"github.com/aiyengar2/hull/pkg/test/coverage/internal"
 	"github.com/aiyengar2/hull/pkg/tpl"
 	"github.com/aiyengar2/hull/pkg/tpl/parse"
-	"github.com/gobwas/glob"
 )
 
 type Tracker struct {
-	FieldUsage map[string]TemplateTracker
+	FieldUsage FieldTracker
 }
 
 func NewTracker(usage *tpl.TemplateUsage, includeSubcharts bool) *Tracker {
@@ -21,24 +20,19 @@ func NewTracker(usage *tpl.TemplateUsage, includeSubcharts bool) *Tracker {
 		return nil
 	}
 
-	var fieldUsage map[string]TemplateTracker
-	var trackFieldsFromResult func(result *parse.Result, templatePath string)
+	var trackFieldsFromResult func(*parse.Result, string, []string)
 
-	trackFieldsFromResult = func(result *parse.Result, templatePath string) {
+	fieldUsage := NewFieldTracker()
+	trackFieldsFromResult = func(result *parse.Result, templatePath string, withinTemplates []string) {
 		for _, field := range result.Fields {
 			if !strings.HasPrefix(field, ".Values") {
 				continue
 			}
-			if fieldUsage == nil {
-				fieldUsage = map[string]TemplateTracker{}
-			}
-			if _, ok := fieldUsage[field]; !ok {
-				fieldUsage[field] = NewTemplateTracker()
-			}
-			fieldUsage[field].Track(templatePath)
+			fieldUsage.Track(field, withinTemplates, templatePath)
 		}
 		for _, templateCall := range result.TemplateCalls {
-			trackFieldsFromResult(usage.NamedTemplates[templateCall], fmt.Sprintf("%s : %s", templateCall, templatePath))
+			newWithinTemplates := append([]string{templateCall}, withinTemplates...)
+			trackFieldsFromResult(usage.NamedTemplates[templateCall], templatePath, newWithinTemplates)
 		}
 	}
 
@@ -46,19 +40,19 @@ func NewTracker(usage *tpl.TemplateUsage, includeSubcharts bool) *Tracker {
 		if !includeSubcharts && strings.HasPrefix(templatePath, "charts/") {
 			continue
 		}
-		trackFieldsFromResult(result, templatePath)
+		trackFieldsFromResult(result, templatePath, nil)
 	}
 	return &Tracker{
 		FieldUsage: fieldUsage,
 	}
 }
 
-func (t *Tracker) Record(templateOptions *chart.TemplateOptions, templateGlobPaths []string) error {
+func (t *Tracker) Record(templateOptions *chart.TemplateOptions, fieldOrNamedTemplates []string) error {
 	if templateOptions == nil {
 		// nothing to track, nothing is modified
 		return nil
 	}
-	if len(templateGlobPaths) == 0 {
+	if len(fieldOrNamedTemplates) == 0 {
 		// nothing to track; nothing is covered
 		return nil
 	}
@@ -148,15 +142,9 @@ func (t *Tracker) Record(templateOptions *chart.TemplateOptions, templateGlobPat
 	}
 
 	// Add trackers
-	for _, templateGlobPath := range templateGlobPaths {
-		for _, field := range setFields {
-			templateTracker, ok := t.FieldUsage[field]
-			if !ok {
-				continue
-			}
-			if err := templateTracker.SeenIn(templateGlobPath); err != nil {
-				return err
-			}
+	for _, fieldOrNamedTemplate := range fieldOrNamedTemplates {
+		for _, fieldSeen := range setFields {
+			t.FieldUsage.Covered(fieldSeen, fieldOrNamedTemplate)
 		}
 	}
 
@@ -164,16 +152,17 @@ func (t *Tracker) Record(templateOptions *chart.TemplateOptions, templateGlobPat
 }
 
 func (t *Tracker) CalculateCoverage() (float64, string) {
-	if t == nil || t.FieldUsage == nil {
+	if t == nil || t.FieldUsage == nil || len(t.FieldUsage) == 0 {
 		return 0, "No keys exist in chart"
 	}
 	var usedReferences, unusedReferences []string
 	var numReferences, numUsedReferences float64
-	for field, templateTracker := range t.FieldUsage {
-		for template, tracked := range templateTracker {
-			ref := fmt.Sprintf("{{ %s }} : %s", field, template)
+	for key, templateTracker := range t.FieldUsage {
+		for _, template := range templateTracker.Templates {
+			splitKey := strings.Split(key, " : ")
+			ref := fmt.Sprintf("{{ %s }} : %s", splitKey[0], strings.Join(append(splitKey[1:], template), " : "))
 			numReferences++
-			if tracked {
+			if templateTracker.IsCovered() {
 				usedReferences = append(usedReferences, ref)
 				numUsedReferences++
 			} else {
@@ -201,27 +190,67 @@ func (t *Tracker) CalculateCoverage() (float64, string) {
 			strings.Join(usedReferences, "\n- ")
 }
 
-type TemplateTracker map[string]bool
+type FieldTracker map[string]*TemplateTracker
 
-func NewTemplateTracker() TemplateTracker {
-	return map[string]bool{}
+func NewFieldTracker() FieldTracker {
+	return map[string]*TemplateTracker{}
 }
 
-func (t TemplateTracker) Track(templatePath string) {
-	t[templatePath] = false
-}
-
-func (t TemplateTracker) SeenIn(templateGlobPath string) error {
-	glob, err := glob.Compile(templateGlobPath)
-	if err != nil {
-		return err
+func (f FieldTracker) Track(field string, withinTemplates []string, templatePath string) {
+	var key string
+	if withinTemplates == nil {
+		key = field
+	} else {
+		key = fmt.Sprintf("%s : %s", field, strings.Join(withinTemplates, " : "))
 	}
-	for templatePaths := range t {
-		for _, templatePath := range strings.Split(templatePaths, " : ") {
-			if glob.Match(templatePath) {
-				t[templatePaths] = true
+	_, ok := f[key]
+	if !ok {
+		f[key] = NewTemplateTracker()
+	}
+	f[key].Track(templatePath)
+}
+
+func (f FieldTracker) Covered(fieldSeen, fieldOrNamedTemplate string) {
+	for key, tt := range f {
+		fieldPaths := strings.Split(key, " : ")
+		currField := fieldPaths[0]
+		if fieldSeen != currField {
+			// only should cover when the field is actually seen
+			continue
+		}
+		for _, fieldPath := range fieldPaths {
+			// once the field has been seen, allow the fieldOrNamedTemplate to
+			// match against any reference of that field. i.e. the field
+			// itself or template(s) it resides in
+			if fieldPath == fieldOrNamedTemplate {
+				tt.Covered()
 			}
 		}
 	}
-	return nil
+}
+
+type TemplateTracker struct {
+	Templates []string
+	covered   bool
+}
+
+func NewTemplateTracker() *TemplateTracker {
+	return &TemplateTracker{}
+}
+
+func (t *TemplateTracker) Track(templatePath string) {
+	if t.Templates == nil {
+		t.Templates = []string{templatePath}
+		return
+	}
+	t.Templates = append(t.Templates, templatePath)
+	sort.Strings(t.Templates)
+}
+
+func (t *TemplateTracker) Covered() {
+	t.covered = true
+}
+
+func (t *TemplateTracker) IsCovered() bool {
+	return t.covered
 }

--- a/pkg/test/suite_test.go
+++ b/pkg/test/suite_test.go
@@ -145,8 +145,10 @@ func TestRun(t *testing.T) {
 
 			NamedChecks: []NamedCheck{
 				{
-					Name:   "Noop",
-					Covers: []string{"templates/configmap.yaml"},
+					Name: "Noop",
+
+					Covers: []string{".Values.data"},
+
 					Checks: Checks{
 						checker.NewChainedCheckFunc[struct{}](nil),
 					},
@@ -155,15 +157,15 @@ func TestRun(t *testing.T) {
 
 			Cases: []Case{
 				{
-					Name:            "Using Defaults",
+					Name: "Using Defaults",
+
 					TemplateOptions: chart.NewTemplateOptions(defaultReleaseName, defaultNamespace),
 				},
 				{
 					Name: "Set Data",
+
 					TemplateOptions: chart.NewTemplateOptions(defaultReleaseName, defaultNamespace).
-						Set("data", map[string]string{
-							"hello": "world",
-						}),
+						Set("data", map[string]string{"hello": "world"}),
 				},
 			},
 
@@ -175,7 +177,7 @@ func TestRun(t *testing.T) {
 						SetValue("shouldFail", "true"),
 
 					Covers: []string{
-						"templates/configmap.yaml",
+						".Values.shouldFail",
 					},
 
 					FailureMessage: ".Values.shouldFail is set to true",
@@ -187,7 +189,7 @@ func TestRun(t *testing.T) {
 						SetValue("shouldFailRequired", "true"),
 
 					Covers: []string{
-						"templates/configmap.yaml",
+						".Values.shouldFailRequired",
 					},
 
 					FailureMessage: ".Values.shouldFailRequired is set to true",


### PR DESCRIPTION
With the new changes in https://github.com/aiyengar2/hull/pull/26 that allow for Checks that are parametrized according to the `values.yaml` of the Case it is running, it makes more sense to allow NamedChecks and FailureCases to identify what they seek to cover based on the field or named template they are targeting, not the place in which that field was found.

This is a breaking change.